### PR TITLE
Add debug output folder and Mergify configuration

### DIFF
--- a/.github/workflows/prci.yml
+++ b/.github/workflows/prci.yml
@@ -43,12 +43,18 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      # The `runner` context is not available in the job-level `env` directive so we set up this variable here instead
+      - name: Set up debug output directory variable
+        run: echo "DEBUG_OUTPUT_FOLDER=${{ runner.temp }}/debug" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Set up scraper
         id: scraper
         uses: ./
+        env:
+          DEBUG_OUTPUT_FOLDER: ${{ env.DEBUG_OUTPUT_FOLDER }}
         with:
           set-up-only: true
+          debug-out: ${{ env.DEBUG_OUTPUT_FOLDER }}
       - name: Check AVD cache
         uses: actions/cache@v4
         id: avd-cache
@@ -94,9 +100,11 @@ jobs:
             ${{ steps.scraper.outputs.command }} >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v4
         if: failure()
+        env:
+          DEBUG_OUTPUT_FOLDER: ${{ env.DEBUG_OUTPUT_FOLDER }}
         with:
-          name: last_screenshot.png
-          path: last_screenshot.png
+          name: debug-output
+          path: ${{ env.DEBUG_OUTPUT_FOLDER }}
           if-no-files-found: ignore
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ dist/
 wheels/
 *.egg-info
 .ruff_cache/
-last_screenshot.png
 
 # Virtual environments
 .venv

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: Automatic merge for pre-commit ci updates
+    description: Merge pre-commit ci autoupdate PR if it passes all branch protection
+    conditions:
+      - author=pre-commit-ci[bot]
+      - title=[pre-commit.ci] pre-commit autoupdate
+    actions:
+      merge:
+        method: merge

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For an example of a repo that uses this action, see https://github.com/kevincon/
 | `password`                  | <p>NissanConnect® account password to use to sign into the app. If either <code>user-id</code> or <code>password</code> is not provided, the app will enter "demo mode" instead of signing in.</p>       | `false`  | `""`    |
 | `android-app-version`       | <p>The version of the NissanConnect® Android app to use. If not provided, defaults to latest version. Caching of the app binary is only enabled if provided.</p>                                         | `false`  | `""`    |
 | `convert-times-to-timezone` | <p>The timezone to convert times to, e.g. "US/Pacific". See the "TZ identifier" column on this page for accepted values: https://en.wikipedia.org/wiki/List<em>of</em>tz<em>database</em>time_zones.</p> | `false`  | `UTC`   |
+| `debug-out`                 | <p>Folder in which to save debug info (e.g. a screenshot of the device in case of failure). Will be created if it does not exist.</p>                                                                    | `false`  | `""`    |
 | `set-up-only`               | <p>Set up the environment only, do not scrape, and include the command that can be executed to scrape in outputs.</p>                                                                                    | `false`  | `""`    |
 
 <!-- action-docs-inputs source="action.yml" -->
@@ -81,6 +82,12 @@ For an example of a repo that uses this action, see https://github.com/kevincon/
     #
     # Required: false
     # Default: UTC
+
+    debug-out:
+    # Folder in which to save debug info (e.g. a screenshot of the device in case of failure). Will be created if it does not exist.
+    #
+    # Required: false
+    # Default: ""
 
     set-up-only:
     # Set up the environment only, do not scrape, and include the command that can be executed to scrape in outputs.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
     description: 'The timezone to convert times to, e.g. "US/Pacific". See the "TZ identifier" column on this page for accepted values: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.'
     required: false
     default: "UTC"
+  debug-out:
+    description: "Folder in which to save debug info (e.g. a screenshot of the device in case of failure). Will be created if it does not exist."
+    required: false
   set-up-only:
     description: "Set up the environment only, do not scrape, and include the command that can be executed to scrape in outputs."
     required: false
@@ -64,8 +67,9 @@ runs:
       with:
         version: "0.6.x"
         enable-cache: true
-        prune-cache: ${{ runner.environment != 'self-hosted'}}
+        prune-cache: ${{ runner.environment != 'self-hosted' }}
         cache-dependency-glob: "${{ env.UV_LOCK_PATH }}"
+        ignore-empty-workdir: true
     - name: Set up node
       uses: actions/setup-node@v4
       with:
@@ -102,12 +106,8 @@ runs:
     - name: Construct scrape command
       shell: bash
       id: construct-scrape-command
-      env:
-        NISSAN_CONNECT_USER_ID: ${{ inputs.user-id }}
-        NISSAN_CONNECT_PASSWORD: ${{ inputs.password }}
-        CONVERT_TIMES_TO_TIMEZONE: ${{ inputs.convert-times-to-timezone }}
       run: |
-        echo 'command=env NISSAN_CONNECT_USER_ID="${{ env.NISSAN_CONNECT_USER_ID }}" NISSAN_CONNECT_PASSWORD="${{ env.NISSAN_CONNECT_PASSWORD }}" CONVERT_TIMES_TO_TIMEZONE="${{ env.CONVERT_TIMES_TO_TIMEZONE }}" uv run --directory="${{ github.action_path }}" main.py "${{ env.APK_FOLDER }}/${{ env.APK_BASE_NAME }}.apk"' >> $GITHUB_OUTPUT
+        echo 'command=env NISSAN_CONNECT_USER_ID="${{ inputs.user-id }}" NISSAN_CONNECT_PASSWORD="${{ inputs.password }}" CONVERT_TIMES_TO_TIMEZONE="${{ inputs.convert-times-to-timezone }}" DEBUG_OUT="${{ inputs.debug-out }}" uv run --directory="${{ github.action_path }}" main.py "${{ env.APK_FOLDER }}/${{ env.APK_BASE_NAME }}.apk"' >> $GITHUB_OUTPUT
     - name: Run scrape command
       if: ${{ !inputs.set-up-only }}
       shell: bash


### PR DESCRIPTION
This PR adds better debugging capabilities and error handling to the Nissan Connect scraper action:

- Added a debug output folder parameter to store diagnostic information
- Replaced single screenshot artifact with a comprehensive debug output folder
- Configured GitHub Actions to upload all debug artifacts on failure
- Added Mergify configuration for automatic merging of pre-commit CI updates
- Renamed `appium_server_url` parameter to more accurate `appium_server_address`
- Increased refresh status timeout from 30 to 90 seconds for more reliable data collection
- Added `ignore-empty-workdir: true` to uv setup step
- Improved environment variable handling in the action workflow
- Removed `last_screenshot.png` from gitignore as it's no longer needed

These changes make troubleshooting failures easier and improve the overall reliability of the scraper.