### PR TITLE
Add customizable last refresh date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,15 @@ For an example of a repo that uses this action, see https://github.com/kevincon/
 
 ## Inputs
 
-| name                        | description                                                                                                                                                                                              | required | default |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| `user-id`                   | <p>NissanConnect® account user ID to use to sign into the app. If either <code>user-id</code> or <code>password</code> is not provided, the app will enter "demo mode" instead of signing in.</p>        | `false`  | `""`    |
-| `password`                  | <p>NissanConnect® account password to use to sign into the app. If either <code>user-id</code> or <code>password</code> is not provided, the app will enter "demo mode" instead of signing in.</p>       | `false`  | `""`    |
-| `android-app-version`       | <p>The version of the NissanConnect® Android app to use. If not provided, defaults to latest version. Caching of the app binary is only enabled if provided.</p>                                         | `false`  | `""`    |
-| `convert-times-to-timezone` | <p>The timezone to convert times to, e.g. "US/Pacific". See the "TZ identifier" column on this page for accepted values: https://en.wikipedia.org/wiki/List<em>of</em>tz<em>database</em>time_zones.</p> | `false`  | `UTC`   |
-| `debug-out`                 | <p>Folder in which to save debug info (e.g. a screenshot of the device in case of failure). Will be created if it does not exist.</p>                                                                    | `false`  | `""`    |
-| `set-up-only`               | <p>Set up the environment only, do not scrape, and include the command that can be executed to scrape in outputs.</p>                                                                                    | `false`  | `""`    |
+| name                        | description                                                                                                                                                                                            | required | default                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------------------- |
+| `user-id`                   | <p>NissanConnect® account user ID to use to sign into the app. If either <code>user-id</code> or <code>password</code> is not provided, the app will enter "demo mode" instead of signing in.</p>      | `false`  | `""`                    |
+| `password`                  | <p>NissanConnect® account password to use to sign into the app. If either <code>user-id</code> or <code>password</code> is not provided, the app will enter "demo mode" instead of signing in.</p>     | `false`  | `""`                    |
+| `android-app-version`       | <p>The version of the NissanConnect® Android app to use. If not provided, defaults to latest version. Caching of the app binary is only enabled if provided.</p>                                       | `false`  | `""`                    |
+| `last-refresh-date-format`  | <p>The format to use for the last refresh date. See https://arrow.readthedocs.io/en/latest/guide.html#supported-tokens for accepted tokens.</p>                                                        | `false`  | `MMM DD, YYYY, hh:mm A` |
+| `convert-times-to-timezone` | <p>A timezone to convert times to, e.g. "US/Pacific". See the "TZ identifier" column on this page for accepted values: https://en.wikipedia.org/wiki/List<em>of</em>tz<em>database</em>time_zones.</p> | `false`  | `""`                    |
+| `debug-out`                 | <p>Folder in which to save debug info (e.g. a screenshot of the device in case of failure). Will be created if it does not exist.</p>                                                                  | `false`  | `""`                    |
+| `set-up-only`               | <p>Set up the environment only, do not scrape, and include the command that can be executed to scrape in outputs.</p>                                                                                  | `false`  | `""`                    |
 
 <!-- action-docs-inputs source="action.yml" -->
 
@@ -39,16 +40,16 @@ For an example of a repo that uses this action, see https://github.com/kevincon/
 
 ## Outputs
 
-| name                         | description                                                                                                                              |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `last-refresh-date`          | <p>The last refresh date (e.g. "Fri 05:30 AM").</p>                                                                                      |
-| `battery-state-of-charge`    | <p>The state of charge of the battery (out of 100, e.g. "75").</p>                                                                       |
-| `charger-state`              | <p>The charger state (e.g. "UNPLUGGED…").</p>                                                                                            |
-| `range-minimum`              | <p>The minimum range in your account's preferred units (e.g. "125" miles).</p>                                                           |
-| `range-maximum`              | <p>The maximum range in your account's preferred units (e.g. "129" miles).</p>                                                           |
-| `interior-temperature-range` | <p>The interior temperature range in your account's preferred units (e.g. "74-84°F").</p>                                                |
-| `level-two-charger-eta`      | <p>The level two charger ETA (e.g. "4h:30m").</p>                                                                                        |
-| `command`                    | <p>A command to run to scrape the NissanConnect® Android app. This is only set if the input <code>set-up-only</code> is set to true.</p> |
+| name                         | description                                                                                                                                                             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `last-refresh-date`          | <p>The last refresh date (e.g. "MAR 05, 2025, 06:31 AM"). The format of this string can be customized using the <code>last-refresh-date-format</code> input option.</p> |
+| `battery-state-of-charge`    | <p>The state of charge of the battery (out of 100, e.g. "75").</p>                                                                                                      |
+| `charger-state`              | <p>The charger state (e.g. "UNPLUGGED…").</p>                                                                                                                           |
+| `range-minimum`              | <p>The minimum range in your account's preferred units (e.g. "125" miles).</p>                                                                                          |
+| `range-maximum`              | <p>The maximum range in your account's preferred units (e.g. "129" miles).</p>                                                                                          |
+| `interior-temperature-range` | <p>The interior temperature range in your account's preferred units (e.g. "74-84°F").</p>                                                                               |
+| `level-two-charger-eta`      | <p>The level two charger ETA (e.g. "4h:30m").</p>                                                                                                                       |
+| `command`                    | <p>A command to run to scrape the NissanConnect® Android app. This is only set if the input <code>set-up-only</code> is set to true.</p>                                |
 
 <!-- action-docs-outputs source="action.yml" -->
 
@@ -77,11 +78,17 @@ For an example of a repo that uses this action, see https://github.com/kevincon/
     # Required: false
     # Default: ""
 
-    convert-times-to-timezone:
-    # The timezone to convert times to, e.g. "US/Pacific". See the "TZ identifier" column on this page for accepted values: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+    last-refresh-date-format:
+    # The format to use for the last refresh date. See https://arrow.readthedocs.io/en/latest/guide.html#supported-tokens for accepted tokens.
     #
     # Required: false
-    # Default: UTC
+    # Default: MMM DD, YYYY, hh:mm A
+
+    convert-times-to-timezone:
+    # A timezone to convert times to, e.g. "US/Pacific". See the "TZ identifier" column on this page for accepted values: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+    #
+    # Required: false
+    # Default: ""
 
     debug-out:
     # Folder in which to save debug info (e.g. a screenshot of the device in case of failure). Will be created if it does not exist.

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,13 @@ inputs:
   android-app-version:
     description: "The version of the NissanConnect® Android app to use. If not provided, defaults to latest version. Caching of the app binary is only enabled if provided."
     required: false
-  convert-times-to-timezone:
-    description: 'The timezone to convert times to, e.g. "US/Pacific". See the "TZ identifier" column on this page for accepted values: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.'
+  last-refresh-date-format:
+    description: "The format to use for the last refresh date. See https://arrow.readthedocs.io/en/latest/guide.html#supported-tokens for accepted tokens."
     required: false
-    default: "UTC"
+    default: "MMM DD, YYYY, hh:mm A"
+  convert-times-to-timezone:
+    description: 'A timezone to convert times to, e.g. "US/Pacific". See the "TZ identifier" column on this page for accepted values: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.'
+    required: false
   debug-out:
     description: "Folder in which to save debug info (e.g. a screenshot of the device in case of failure). Will be created if it does not exist."
     required: false
@@ -27,7 +30,7 @@ inputs:
     default: ""
 outputs:
   last-refresh-date:
-    description: 'The last refresh date (e.g. "Fri 05:30 AM").'
+    description: 'The last refresh date (e.g. "MAR 05, 2025, 06:31 AM"). The format of this string can be customized using the `last-refresh-date-format` input option.'
     value: ${{ steps.run-and-scrape.outputs.last-refresh-date }}
   battery-state-of-charge:
     description: 'The state of charge of the battery (out of 100, e.g. "75").'


### PR DESCRIPTION
This PR adds a new input parameter `last-refresh-date-format` that allows users to customize the format of the last refresh date in the output. The default format is now "MMM DD, YYYY, hh:mm A" (e.g., "MAR 05, 2025, 06:31 AM"), which matches the default format used by the Nissan Connect app (at least at time of writing).

The PR also improves timezone handling:
- Changed the default for `convert-times-to-timezone` from "UTC" to empty string
- Updated the description to clarify it's "A timezone" rather than "The timezone"
- Fixed timezone handling in the code to properly use the Android device's timezone as the source

The documentation has been updated to reflect these changes, including links to the Arrow library's supported date format tokens.