### PR TITLE
Inherit secrets when calling PRCI from Main workflow

### DIFF
--- a/.github/workflows/mainci.yml
+++ b/.github/workflows/mainci.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   prci:
     uses: ./.github/workflows/prci.yml
+    secrets: inherit # pragma: allowlist secret
   release:
     name: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Grr: https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/sharing-automations/reuse-workflows#passing-secrets-to-nested-workflows